### PR TITLE
Renaming everything with an 'rcl_' prefix instead of an 'rc_' prefix …

### DIFF
--- a/rcl_logging_log4cxx/CMakeLists.txt
+++ b/rcl_logging_log4cxx/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(rc_logging_noop)
+project(rcl_logging_log4cxx)
 
 # Default to C11
 if(NOT CMAKE_C_STANDARD)
@@ -13,6 +13,10 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 
+set(dependencies
+    log4cxx
+)
+
 include_directories(${ament_INCLUDE_DIRS})
 
 if(NOT WIN32)
@@ -20,18 +24,11 @@ if(NOT WIN32)
 endif()
 
 set(${PROJECT_NAME}_sources
-    src/rc_logging_noop/rc_logging_noop.cpp
+    src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
 )
 #set_source_files_properties(${${PROJECT_NAME}_sources} PROPERTIES language "CXX")
 
-if(NOT WIN32)
-  add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
-else()
-  # TODO(nburek): There is an issue with build on Windows where it is looking for a static lib
-  # and can't find it when trying to call find_package() for this package. This explicitly creates
-  # it.
-  add_library(${PROJECT_NAME} STATIC ${${PROJECT_NAME}_sources})
-endif()
+add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
 
 ament_target_dependencies(${PROJECT_NAME}
     ${dependencies}

--- a/rcl_logging_log4cxx/Doxyfile
+++ b/rcl_logging_log4cxx/Doxyfile
@@ -1,8 +1,8 @@
 # All settings not listed here will use the Doxygen default values.
 
-PROJECT_NAME           = "rc_external_logging"
+PROJECT_NAME           = "rcl_external_logging"
 PROJECT_NUMBER         = master
-PROJECT_BRIEF          = "A shared library implementation of rc_external_logging that utilizes the log4cxx library."
+PROJECT_BRIEF          = "A shared library implementation of rcl_external_logging that utilizes the log4cxx library."
 
 # Use these lines to include the generated logging_macro.h (update install path if needed)
 #INPUT                  = README.md ../../../install_isolated/rcutils/include

--- a/rcl_logging_log4cxx/package.xml
+++ b/rcl_logging_log4cxx/package.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>rc_logging_noop</name>
+  <name>rcl_logging_log4cxx</name>
   <version>0.1.0</version>
-  <description>An rc logger implementation that doesn't do anything with log messages.</description>
+  <description>C API providing common interface to a shared library wrapping 3rd party loggers.</description>
   <maintainer email="amazon-b9-ros@amazon.com">Amazon B9</maintainer>
   <author email="amazon-b9-ros@amazon.com">Nick Burek</author>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>python3-empy</buildtool_depend>
+
+  <depend>log4cxx</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
@@ -18,7 +20,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>launch_testing</test_depend>
 
-  <member_of_group>rc_logging_packages</member_of_group>
+  <member_of_group>rcl_logging_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
+++ b/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
@@ -34,7 +34,7 @@
 
 extern "C" {
 
-typedef int rc_logging_ret_t;
+typedef int rcl_logging_ret_t;
 #define RC_LOGGING_RET_OK                          (0)
 #define RC_LOGGING_RET_WARN                        (1)
 #define RC_LOGGING_RET_ERROR                       (2)
@@ -85,13 +85,13 @@ static const log4cxx::LevelPtr map_external_log_level_to_library_level(int exter
   return level;
 }
 
-rc_logging_ret_t rcl_logging_external_initialize(const char * config_file)
+rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file)
 {
   log4cxx::File file(config_file);
   log4cxx::helpers::Pool pool;
   bool config_file_provided = (nullptr != config_file) && (config_file[0] != '\0');
   bool use_default_config = !config_file_provided;
-  rc_logging_ret_t status = RC_LOGGING_RET_OK;
+  rcl_logging_ret_t status = RC_LOGGING_RET_OK;
 
   if (config_file_provided && !file.exists(pool)) {
     // The provided config file doesn't exist, fall back to using default configuration
@@ -122,7 +122,7 @@ rc_logging_ret_t rcl_logging_external_initialize(const char * config_file)
   return status;
 }
 
-rc_logging_ret_t rcl_logging_external_shutdown()
+rcl_logging_ret_t rcl_logging_external_shutdown()
 {
   log4cxx::BasicConfigurator::resetConfiguration();
   return RC_LOGGING_RET_OK;
@@ -135,7 +135,7 @@ void rcl_logging_external_log(int severity, const char * name, const char * msg)
   logger->log(level, msg);
 }
 
-rc_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
+rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
 {
   log4cxx::LoggerPtr logger(get_logger(name));
   logger->setLevel(map_external_log_level_to_library_level(level));

--- a/rcl_logging_noop/CMakeLists.txt
+++ b/rcl_logging_noop/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(rc_logging_log4cxx)
+project(rcl_logging_noop)
 
 # Default to C11
 if(NOT CMAKE_C_STANDARD)
@@ -13,10 +13,6 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 
-set(dependencies
-    log4cxx
-)
-
 include_directories(${ament_INCLUDE_DIRS})
 
 if(NOT WIN32)
@@ -24,11 +20,18 @@ if(NOT WIN32)
 endif()
 
 set(${PROJECT_NAME}_sources
-    src/rc_logging_log4cxx/rc_logging_log4cxx.cpp
+    src/rcl_logging_noop/rcl_logging_noop.cpp
 )
 #set_source_files_properties(${${PROJECT_NAME}_sources} PROPERTIES language "CXX")
 
-add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
+if(NOT WIN32)
+  add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
+else()
+  # TODO(nburek): There is an issue with build on Windows where it is looking for a static lib
+  # and can't find it when trying to call find_package() for this package. This explicitly creates
+  # it.
+  add_library(${PROJECT_NAME} STATIC ${${PROJECT_NAME}_sources})
+endif()
 
 ament_target_dependencies(${PROJECT_NAME}
     ${dependencies}

--- a/rcl_logging_noop/Doxyfile
+++ b/rcl_logging_noop/Doxyfile
@@ -1,8 +1,8 @@
 # All settings not listed here will use the Doxygen default values.
 
-PROJECT_NAME           = "rc_external_logging"
+PROJECT_NAME           = "rcl_logging_noop"
 PROJECT_NUMBER         = master
-PROJECT_BRIEF          = "A shared library implementation of rc_external_logging that utilizes the log4cxx library."
+PROJECT_BRIEF          = "A library implementation of the rcl_logging interface that does nothing."
 
 # Use these lines to include the generated logging_macro.h (update install path if needed)
 #INPUT                  = README.md ../../../install_isolated/rcutils/include

--- a/rcl_logging_noop/package.xml
+++ b/rcl_logging_noop/package.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>rc_logging_log4cxx</name>
+  <name>rcl_logging_noop</name>
   <version>0.1.0</version>
-  <description>C API providing common interface to a shared library wrapping 3rd party loggers.</description>
+  <description>An rc logger implementation that doesn't do anything with log messages.</description>
   <maintainer email="amazon-b9-ros@amazon.com">Amazon B9</maintainer>
   <author email="amazon-b9-ros@amazon.com">Nick Burek</author>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>python3-empy</buildtool_depend>
-
-  <depend>log4cxx</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
@@ -20,7 +18,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>launch_testing</test_depend>
 
-  <member_of_group>rc_logging_packages</member_of_group>
+  <member_of_group>rcl_logging_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rcl_logging_noop/src/rcl_logging_noop/rcl_logging_noop.cpp
+++ b/rcl_logging_noop/src/rcl_logging_noop/rcl_logging_noop.cpp
@@ -15,16 +15,16 @@
 
 extern "C" {
 
-typedef int rc_logging_ret_t;
+typedef int rcl_logging_ret_t;
 #define RC_LOGGING_RET_OK   (0)
 
-rc_logging_ret_t rcl_logging_external_initialize(const char * config_file)
+rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file)
 {
   (void) config_file;
   return RC_LOGGING_RET_OK;
 }
 
-rc_logging_ret_t rcl_logging_external_shutdown()
+rcl_logging_ret_t rcl_logging_external_shutdown()
 {
   return RC_LOGGING_RET_OK;
 }
@@ -36,7 +36,7 @@ void rcl_logging_external_log(int severity, const char * name, const char * msg)
   (void) msg;
 }
 
-rc_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
+rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
 {
   (void) name;
   (void) level;


### PR DESCRIPTION
Renaming everything with an 'rcl_' prefix instead of an 'rc_' prefix to match the change in 'rcl'

Connects to https://github.com/ros2/rcl/pull/327